### PR TITLE
make this work (?)

### DIFF
--- a/upload_stats/__init__.py
+++ b/upload_stats/__init__.py
@@ -346,7 +346,7 @@ Only files that have been uploaded more than this will be shown on the statistic
                                  'A new update is available. Current: {current} New: {new}'.format(
                                      current=tag('kbd', __version__),
                                      new=tag('kbd', self.update_version[1:])
-                                 ), href=self.update_url + self.update_version, target='_blank')
+                                 ), href=self.update_url, target='_blank')
 
         max_day = max(self.stats['day']) or 1
         for index, day in enumerate(self.stats['day']):


### PR DESCRIPTION
i dont have a local environment of this set up, however this is what i presume to be the fix to this.

intended functionality -> https://github.com/Nachtalb/more-upload-stats/releases/tag/v2.1.1
current functionality -> https://github.com/Nachtalb/more-upload-stats/releases/tag/v2.1.1v2.1.1

another way of handling this would be just to change all update urls to "https://github.com/Nachtalb/more-upload-stats/releases/latest"